### PR TITLE
feat: allow users to view past generations

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2,5 +2,6 @@
     "GenGIFCommandExample": "gen-gif \"your-prompt-here\"",
     "GenGIFCommandDescription": "Generate a GIF from a prompt",
     "PreviewTitle_Loading": "Loading",
-    "PreviewTitle_Generated": "Generated GIF's"
+    "PreviewTitle_Generated": "Generated GIF's",
+    "PreviewTitle_Past_Creations": "Your Creations"
 }

--- a/src/commands/CommandUtility.ts
+++ b/src/commands/CommandUtility.ts
@@ -71,6 +71,10 @@ export class CommandUtility implements ICommandUtility {
             case "query": {
                 return await handler.executePromptGeneration();
             }
+            case "h":
+            case "history": {
+                return await handler.executeHistory();
+            }
             default: {
                 return {
                     i18nTitle: "PreviewTitle_Loading",

--- a/src/commands/GenGifCommand.ts
+++ b/src/commands/GenGifCommand.ts
@@ -12,6 +12,7 @@ import {
 } from "@rocket.chat/apps-engine/definition/slashcommands";
 import { AiGifApp } from "../../AiGifApp";
 import { RequestDebouncer } from "../helper/RequestDebouncer";
+import { GenerationPersistence } from "../persistence/GenerationPersistence";
 import { CommandUtility } from "./CommandUtility";
 
 export class GenGifCommand implements ISlashCommand {

--- a/src/endpoints/GifStatusUpdateEndpoint.ts
+++ b/src/endpoints/GifStatusUpdateEndpoint.ts
@@ -12,6 +12,7 @@ import {
 } from "@rocket.chat/apps-engine/definition/accessors";
 import { OnGoingGenPersistence } from "../persistence/OnGoingGenPersistence";
 import { IUpdateEndpointContent } from "../../definition/endpoint/IEndpointContent";
+import { GenerationPersistence } from "../persistence/GenerationPersistence";
 
 export class GifStatusUpdateEndpoint extends ApiEndpoint {
     path = "gif-status-update";
@@ -75,6 +76,17 @@ export class GifStatusUpdateEndpoint extends ApiEndpoint {
 
         // delete record from generation persistence
         await onGoingGenPeristence.deleteRecordById(content.id);
+
+        const generationPersistence = new GenerationPersistence(
+            record.uid,
+            persis,
+            read.getPersistenceReader()
+        );
+
+        await generationPersistence.add({
+            query: record.prompt,
+            url: content.output,
+        });
 
         return {
             status: 200,

--- a/src/handlers/PreviewerHandler.ts
+++ b/src/handlers/PreviewerHandler.ts
@@ -13,6 +13,7 @@ import {
     ISlashCommandPreview,
     SlashCommandPreviewItemType,
 } from "@rocket.chat/apps-engine/definition/slashcommands/ISlashCommandPreview";
+import { GenerationPersistence } from "../persistence/GenerationPersistence";
 
 export class PreviewerHandler {
     app: AiGifApp;
@@ -50,6 +51,7 @@ export class PreviewerHandler {
             this.http,
             this.read,
             this.modify,
+            this.persis,
             this.room,
             this.sender,
             this.threadId
@@ -95,6 +97,25 @@ export class PreviewerHandler {
         return {
             i18nTitle: "PreviewTitle_Generated",
             items,
+        };
+    }
+
+    async executeHistory(): Promise<ISlashCommandPreview> {
+        const generationPersistence = new GenerationPersistence(
+            this.sender.id,
+            this.persis,
+            this.read.getPersistenceReader()
+        );
+
+        const gifs = await generationPersistence.getAllItems();
+
+        return {
+            i18nTitle: "PreviewTitle_Past_Creations",
+            items: gifs.map((gif) => ({
+                id: gif.query,
+                type: SlashCommandPreviewItemType.IMAGE,
+                value: gif.url,
+            })),
         };
     }
 }

--- a/src/lib/GifRequestDispatcher.ts
+++ b/src/lib/GifRequestDispatcher.ts
@@ -239,7 +239,7 @@ export class GifRequestDispatcher {
     }
 
     async mockSyncGenerateGif(prompt: string): Promise<string> {
-        await this.waitForMillis(5000);
+        await this.waitForMillis(2000);
 
         return "https://i.giphy.com/vzO0Vc8b2VBLi.gif";
     }

--- a/src/persistence/GenerationPersistence.ts
+++ b/src/persistence/GenerationPersistence.ts
@@ -1,0 +1,92 @@
+import {
+    IPersistence,
+    IPersistenceRead,
+} from "@rocket.chat/apps-engine/definition/accessors";
+import {
+    RocketChatAssociationModel,
+    RocketChatAssociationRecord,
+} from "@rocket.chat/apps-engine/definition/metadata";
+
+interface GenerationRecord {
+    query: string;
+    url: string;
+}
+
+interface GenerationRecordWrapper {
+    generated_gifs: GenerationRecord[];
+}
+
+export class GenerationPersistence {
+    private key = "gen-gif";
+
+    constructor(
+        readonly userId: string,
+        readonly persistence: IPersistence,
+        readonly persistenceRead: IPersistenceRead
+    ) {}
+
+    async getAll() {
+        const res = await this.persistenceRead.readByAssociations([
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.MISC,
+                this.key
+            ),
+            new RocketChatAssociationRecord(
+                RocketChatAssociationModel.USER,
+                this.userId
+            ),
+        ]);
+        return res;
+    }
+
+    async getAllItems(): Promise<GenerationRecord[]> {
+        const records = await this.getAll();
+        if (records.length == 0) {
+            return [];
+        }
+        return (records[0] as GenerationRecordWrapper).generated_gifs;
+    }
+
+    async add(record: GenerationRecord): Promise<void> {
+        const records = await this.getAll();
+
+        if (!records || records.length == 0) {
+            await this.persistence.createWithAssociations(
+                {
+                    generated_gifs: [record],
+                },
+                [
+                    new RocketChatAssociationRecord(
+                        RocketChatAssociationModel.MISC,
+                        this.key
+                    ),
+                    new RocketChatAssociationRecord(
+                        RocketChatAssociationModel.USER,
+                        this.userId
+                    ),
+                ]
+            );
+        } else {
+            await this.persistence.updateByAssociations(
+                [
+                    new RocketChatAssociationRecord(
+                        RocketChatAssociationModel.MISC,
+                        this.key
+                    ),
+
+                    new RocketChatAssociationRecord(
+                        RocketChatAssociationModel.USER,
+                        this.userId
+                    ),
+                ],
+                {
+                    generated_gifs: [
+                        record,
+                        ...(records[0] as GenerationRecordWrapper)
+                            .generated_gifs,
+                    ],
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Description

Allows users to view past generations. Implemented using `IPersistence` and storing the generations using multiple associations. The generations are uniquely stored for each user, and can be viewed by passing `h` or `history` as the first parameter to the `gen-gif` command.

### Preview

https://github.com/RocketChat/Apps.AI.GIF/assets/37607224/a8db8f13-a3d2-4c08-a7f1-91bd8786d183

> Fixes: #3 
