### PR TITLE
bug: support upload GIF to RC Channel

### DIFF
--- a/app.json
+++ b/app.json
@@ -49,6 +49,9 @@
         },
         {
             "name": "message.read"
+        },
+        {
+            "name": "upload.write"
         }
     ]
 }

--- a/definition/handlers/IPreviewId.ts
+++ b/definition/handlers/IPreviewId.ts
@@ -1,0 +1,5 @@
+export interface IPreviewId {
+    id: string;
+    prompt: string;
+    origin: string;
+}

--- a/src/commands/CommandUtility.ts
+++ b/src/commands/CommandUtility.ts
@@ -21,6 +21,11 @@ import {
 import { PreviewItemHandler } from "../handlers/PreviewItemHandler";
 import { sendMessageToSelf } from "../utils/message";
 import { InfoMessages } from "../enum/InfoMessages";
+import { sendGifToRoom, uploadGifToRoom } from "../utils/message";
+import { IPreviewId } from "../../definition/handlers/IPreviewId";
+import { PreviewOrigin } from "../enum/PreviewOrigin";
+import { GenerationPersistence } from "../persistence/GenerationPersistence";
+import { uuid } from "../utils/uuid";
 
 export class CommandUtility implements ICommandUtility {
     app: AiGifApp;
@@ -130,11 +135,11 @@ export class CommandUtility implements ICommandUtility {
 
         switch (item.type) {
             case SlashCommandPreviewItemType.TEXT: {
-                await handler.requestGenerationFromPrompt();
+                await handler.handleTextPreviewItem();
                 break;
             }
             case SlashCommandPreviewItemType.IMAGE: {
-                await handler.sendGifToRoom();
+                await handler.handleImagePreviewItem();
                 break;
             }
             default: {

--- a/src/commands/CommandUtility.ts
+++ b/src/commands/CommandUtility.ts
@@ -21,11 +21,6 @@ import {
 import { PreviewItemHandler } from "../handlers/PreviewItemHandler";
 import { sendMessageToSelf } from "../utils/message";
 import { InfoMessages } from "../enum/InfoMessages";
-import { sendGifToRoom, uploadGifToRoom } from "../utils/message";
-import { IPreviewId } from "../../definition/handlers/IPreviewId";
-import { PreviewOrigin } from "../enum/PreviewOrigin";
-import { GenerationPersistence } from "../persistence/GenerationPersistence";
-import { uuid } from "../utils/uuid";
 
 export class CommandUtility implements ICommandUtility {
     app: AiGifApp;

--- a/src/endpoints/GifStatusUpdateEndpoint.ts
+++ b/src/endpoints/GifStatusUpdateEndpoint.ts
@@ -134,18 +134,6 @@ export class GifStatusUpdateEndpoint extends ApiEndpoint {
         // delete record from generation persistence
         await onGoingGenPeristence.deleteRecordById(content.id);
 
-        const generationPersistence = new GenerationPersistence(
-            record.uid,
-            persis,
-            read.getPersistenceReader()
-        );
-
-        await generationPersistence.add({
-            id: uuid(),
-            query: record.prompt,
-            url: content.output,
-        });
-
         return {
             status: 200,
             content: {

--- a/src/enum/InfoMessages.ts
+++ b/src/enum/InfoMessages.ts
@@ -6,11 +6,12 @@ export enum InfoMessages {
     MODEL_ID_NOT_SET = "You didn't set the Model ID, please set it to generate gifs.",
     GENERATION_IN_PROGRESS = "Generating the gif, please wait...",
     GENERATION_FAILED = "Failed to generate the gif, please try again later.",
-    PROFANITY_FOUND_MESSAGE = "The text contains profanity. Please provide a different text. \nDetected Words:",
     NO_ITEMS_FOUND_ON_PAGE = "The provided page number is out of range. The last page number is ",
+    PROFANITY_FOUND_MESSAGE = "The text contains profanity. Please provide a different text. \nDetected Words: ",
 }
 
 export enum ErrorMessages {
     PROMPT_VARIATION_FAILED = "Server Error: Failed to get prompt variations, please try again later.",
     INVALID_PAGE_NUMBER = "The provided page number is invalid, please provide a valid page number.",
+    GIF_UPLOAD_FAILED = "An error occcurred while uploading the GIF to channel",
 }

--- a/src/enum/PreviewOrigin.ts
+++ b/src/enum/PreviewOrigin.ts
@@ -1,0 +1,4 @@
+export enum PreviewOrigin {
+    HISTORY = "history",
+    PROMPT_GENERATION = "prompt",
+}

--- a/src/handlers/PreviewerHandler.ts
+++ b/src/handlers/PreviewerHandler.ts
@@ -18,7 +18,9 @@ import { GenerationPersistence } from "../persistence/GenerationPersistence";
 import { uuid } from "../utils/uuid";
 import { RedefinedPrompt } from "../lib/RedefinePrompt";
 import { sendMessageToSelf } from "../utils/message";
-import { ErrorMessages, InfoMessages } from "../enum/InfoMessages";
+import { InfoMessages } from "../enum/InfoMessages";
+import { PreviewOrigin } from "../enum/PreviewOrigin";
+import { IPreviewId } from "../../definition/handlers/IPreviewId";
 
 export class PreviewerHandler {
     app: AiGifApp;
@@ -93,11 +95,17 @@ export class PreviewerHandler {
             };
         }
 
+        const previewId: IPreviewId = {
+            id: uuid(),
+            prompt,
+            origin: PreviewOrigin.PROMPT_GENERATION,
+        };
+
         return {
             i18nTitle: "PreviewTitle_Generated",
             items: [
                 {
-                    id: uuid() + "://" + prompt,
+                    id: JSON.stringify(previewId),
                     type: SlashCommandPreviewItemType.IMAGE,
                     value: res,
                 },
@@ -128,7 +136,6 @@ export class PreviewerHandler {
                 };
             });
         }
-
         return {
             i18nTitle: "PreviewTitle_Generated",
             items,
@@ -154,11 +161,19 @@ export class PreviewerHandler {
 
         return {
             i18nTitle: "PreviewTitle_Past_Creations",
-            items: gifs.map((gif) => ({
-                id: gif.id + "://" + gif.query,
-                type: SlashCommandPreviewItemType.IMAGE,
-                value: gif.url,
-            })),
+            items: gifs.map((gif) => {
+                const previewId: IPreviewId = {
+                    id: gif.id,
+                    prompt: gif.query,
+                    origin: PreviewOrigin.HISTORY,
+                };
+
+                return {
+                    id: JSON.stringify(previewId),
+                    type: SlashCommandPreviewItemType.IMAGE,
+                    value: gif.url,
+                };
+            }),
         };
     }
 

--- a/src/helper/RequestDebouncer.ts
+++ b/src/helper/RequestDebouncer.ts
@@ -13,7 +13,7 @@ import { IUser } from "@rocket.chat/apps-engine/definition/users";
 import { GenerationPersistence } from "../persistence/GenerationPersistence";
 import { uuid } from "../utils/uuid";
 import { sendMessageToSelf } from "../utils/message";
-import { ErrorMessages } from "../enum/InfoMessages";
+import { ErrorMessages, InfoMessages } from "../enum/InfoMessages";
 
 export class RequestDebouncer {
     // generic function to debounce multiple requests to the same function, ensures that only the last request is executed
@@ -99,9 +99,8 @@ export class RequestDebouncer {
                     room,
                     sender,
                     threadId,
-                    `The text contains profanity. Please provide a different text. \nDetected Words: ${profanityRes.profaneWords.join(
-                        ", "
-                    )}`
+                    InfoMessages.PROFANITY_FOUND_MESSAGE +
+                        profanityRes.profaneWords.join(", ")
                 );
                 return [];
             }
@@ -112,7 +111,7 @@ export class RequestDebouncer {
                 sender.id,
                 logger
             );
-            
+
             if (!data) {
                 sendMessageToSelf(
                     modify,
@@ -161,21 +160,6 @@ export class RequestDebouncer {
             );
 
             const res = await gifRequestDispatcher.syncGenerateGif(args);
-
-            if (res && res.trim().length > 0) {
-                // if response is valid, store the gif url for history feature
-                const generationPersistence = new GenerationPersistence(
-                    sender.id,
-                    persis,
-                    read.getPersistenceReader()
-                );
-
-                await generationPersistence.add({
-                    id: uuid().toString(),
-                    query: args,
-                    url: res!,
-                });
-            }
 
             return res;
         },

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -1,6 +1,11 @@
-import { IModify } from "@rocket.chat/apps-engine/definition/accessors";
+import {
+    IHttp,
+    ILogger,
+    IModify,
+} from "@rocket.chat/apps-engine/definition/accessors";
 import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
 import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { ErrorMessages } from "../enum/InfoMessages";
 
 export function sendMessageToSelf(
     modify: IModify,
@@ -22,22 +27,68 @@ export function sendMessageToSelf(
     modify.getNotifier().notifyUser(sender, message.getMessage());
 }
 
-export function sendMessageToRoom(
+export async function uploadGifToRoom(
+    url: string,
+    prompt: string,
+    http: IHttp,
     modify: IModify,
     room: IRoom,
-    sender: IUser,
-    threadId: string | undefined,
-    text: string,
-    emoji: string
-): Promise<string> {
-    const message = modify.getCreator().startMessage({
-        room,
-        sender,
-        threadId,
-        text,
-        emoji,
-        groupable: false,
-    });
+    user: IUser,
+    logger: ILogger,
+    threadId?: string | undefined
+): Promise<string | undefined> {
+    try {
+        const res = await http.get(url, {
+            encoding: null,
+        });
 
-    return modify.getCreator().finish(message);
+        if (res && res.content) {
+            const buffer = Buffer.from(res.content);
+            const fileName: string = prompt.split(" ").join("-");
+            const upload = await modify
+                .getCreator()
+                .getUploadCreator()
+                .uploadBuffer(buffer, {
+                    filename: `${fileName}.gif`,
+                    room,
+                    user: user,
+                });
+
+            return upload.url;
+        }
+        throw new Error("Failed to fetch GIF while uploading GIFf");
+    } catch (e) {
+        logger.error(ErrorMessages.GIF_UPLOAD_FAILED, e);
+        sendMessageToSelf(
+            modify,
+            room,
+            user,
+            threadId,
+            ErrorMessages.GIF_UPLOAD_FAILED
+        );
+        return undefined;
+    }
+}
+
+export async function sendGifToRoom(
+    url: string,
+    prompt: string,
+    modify: IModify,
+    room: IRoom,
+    user: IUser
+) {
+    const messageBuilder = modify
+        .getCreator()
+        .startMessage()
+        .setGroupable(false)
+        .setRoom(room)
+        .setSender(user)
+        .setAttachments([
+            {
+                title: { value: prompt },
+                imageUrl: url,
+            },
+        ]);
+
+    await modify.getCreator().finish(messageBuilder);
 }


### PR DESCRIPTION
 ## Description

> Currently, we use Replicate as our API provider and it usually keeps the generated GIF in the storage for about an hour. By this time it expects that we upload the generated GIF on our own server(which is usually the expected behavior). Currently, after 1 hour the GIF URL becomes invalid and the GIF doesn't appear in chat. Fix this by uploading the GIF to the channel, instead of adding it to the channel as attachment.


Fix:  Upload the GIF using `uploadBuffer()` to the channel once generated/approved.

#### Fixes: #19 

## Preview


https://github.com/user-attachments/assets/d4301f2b-7467-468a-a46e-c410ab8df52d



