### PR TITLE
feat: add help command

### DIFF
--- a/src/commands/CommandUtility.ts
+++ b/src/commands/CommandUtility.ts
@@ -21,6 +21,7 @@ import {
 import { PreviewItemHandler } from "../handlers/PreviewItemHandler";
 import { sendMessageToSelf } from "../utils/message";
 import { InfoMessages } from "../enum/InfoMessages";
+import { Messages } from "../enum/Messages";
 
 export class CommandUtility implements ICommandUtility {
     app: AiGifApp;
@@ -102,6 +103,15 @@ export class CommandUtility implements ICommandUtility {
                     }
                     return preview;
                 }
+            }
+            case "help": {
+                sendMessageToSelf(
+                    this.modify,
+                    this.room,
+                    this.sender,
+                    this.threadId,
+                    Messages.HELPER_TEXT + Messages.HELPER_COMMANDS
+                );
             }
             default: {
                 return {

--- a/src/enum/Messages.ts
+++ b/src/enum/Messages.ts
@@ -1,0 +1,7 @@
+export enum Messages {
+    HELPER_COMMANDS = `• use \`/gen-gif p <yourprompthere>\` to generate GIF using your own prompt.
+        • use \`/gen-gif q <yourqueryhere>\` to get a list of suggested prompts and use them to generate a GIF.
+        • use \`/gen-gif h <page_number>\` to view past generations.
+        `,
+    HELPER_TEXT = `Need some help with \`/gen-gif\`?\n`,
+}


### PR DESCRIPTION
## Issue Description

- Allow users to view how to use the app. 
- Shows a helper message suggesting the available command and how to use them.

```
Need some help with `/gen-gif`?

• use `/gen-gif p <yourprompthere>` to generate GIF using your own prompt.
• use `/gen-gif q <yourqueryhere>` to get a list of suggested prompts and use them to generate a GIF.
• use `/gen-gif h <page_number>` to view past generations.
       
```

#### Fixes: #14 

> PS: Currently, it sends the help command on the user's behalf, this error is known and will be fixed in the BOT PR #20 

## Preview

![image](https://github.com/user-attachments/assets/cb49bcb7-0dbb-4719-8c22-a36a601db8b5)
